### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/bold.php
+++ b/syntax/bold.php
@@ -25,14 +25,14 @@ class syntax_plugin_bbcode_bold extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return array();
     }
  
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/code.php
+++ b/syntax/code.php
@@ -25,14 +25,14 @@ class syntax_plugin_bbcode_code extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return true;
     }
  
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/color.php
+++ b/syntax/color.php
@@ -170,7 +170,7 @@ class syntax_plugin_bbcode_color extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
           case DOKU_LEXER_ENTER :
             $match = substr($match, 7, -1);
@@ -190,7 +190,7 @@ class syntax_plugin_bbcode_color extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml') {
             list($state, $match) = $data;
             switch ($state) {

--- a/syntax/deleted.php
+++ b/syntax/deleted.php
@@ -25,14 +25,14 @@ class syntax_plugin_bbcode_deleted extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return array();
     }
  
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/email.php
+++ b/syntax/email.php
@@ -23,7 +23,7 @@ class syntax_plugin_bbcode_email extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = trim(substr($match, 7, -8));
         $match = preg_split('/\]/u',$match,2);
         if ( !isset($match[0]) ) {
@@ -40,7 +40,7 @@ class syntax_plugin_bbcode_email extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/image.php
+++ b/syntax/image.php
@@ -23,7 +23,7 @@ class syntax_plugin_bbcode_image extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = trim(substr($match, 5, -6));
         $match = preg_split('/\]/u',$match,2);
         if ( !isset($match[0]) ) {
@@ -48,7 +48,7 @@ class syntax_plugin_bbcode_image extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/italic.php
+++ b/syntax/italic.php
@@ -25,14 +25,14 @@ class syntax_plugin_bbcode_italic extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return array();
     }
  
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/link.php
+++ b/syntax/link.php
@@ -23,7 +23,7 @@ class syntax_plugin_bbcode_link extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = substr($match, 5, -6);
         if (preg_match('/".+?"/',$match)) $match = substr($match, 1, -1); // addition #1: unquote
         $match = preg_split('/\]/u',$match,2);
@@ -53,7 +53,7 @@ class syntax_plugin_bbcode_link extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/monospace.php
+++ b/syntax/monospace.php
@@ -25,14 +25,14 @@ class syntax_plugin_bbcode_monospace extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return array();
     }
  
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }

--- a/syntax/olist.php
+++ b/syntax/olist.php
@@ -26,7 +26,7 @@ class syntax_plugin_bbcode_olist extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {        
+    function handle($match, $state, $pos, Doku_Handler $handler) {        
         switch ($state) {
           case DOKU_LEXER_ENTER :
             // get the list type
@@ -47,7 +47,7 @@ class syntax_plugin_bbcode_olist extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml') {
             list($state, $match) = $data;
             switch ($state) {

--- a/syntax/quote.php
+++ b/syntax/quote.php
@@ -26,7 +26,7 @@ class syntax_plugin_bbcode_quote extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {        
+    function handle($match, $state, $pos, Doku_Handler $handler) {        
         switch ($state) {
           case DOKU_LEXER_ENTER :
             $match = explode('"',substr($match, 6, -1));
@@ -45,7 +45,7 @@ class syntax_plugin_bbcode_quote extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml') {
             list($state, $match) = $data;
             switch ($state) {

--- a/syntax/size.php
+++ b/syntax/size.php
@@ -26,7 +26,7 @@ class syntax_plugin_bbcode_size extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
           case DOKU_LEXER_ENTER :
             $match = substr($match, 6, -1);
@@ -48,7 +48,7 @@ class syntax_plugin_bbcode_size extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml') {
             list($state, $match) = $data;
             switch ($state) {

--- a/syntax/ulist.php
+++ b/syntax/ulist.php
@@ -26,7 +26,7 @@ class syntax_plugin_bbcode_ulist extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){        
+    function handle($match, $state, $pos, Doku_Handler $handler){        
         switch ($state) {
           case DOKU_LEXER_ENTER :
             return array($state, '');
@@ -44,7 +44,7 @@ class syntax_plugin_bbcode_ulist extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             list($state, $match) = $data;
             switch ($state) {

--- a/syntax/underline.php
+++ b/syntax/underline.php
@@ -25,14 +25,14 @@ class syntax_plugin_bbcode_underline extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         return array();
     }
  
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         return true;
     }
 }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
